### PR TITLE
Mutate :/ operator only in case when it's an arithmetic operator

### DIFF
--- a/lib/exavier.ex
+++ b/lib/exavier.ex
@@ -116,6 +116,19 @@ defmodule Exavier do
 
   def mutate_all(
     {operator, meta, args} = ast, mutator, lines_to_mutate, already_mutated_lines
+  ) when operator == :& do
+    case Enum.member?(lines_to_mutate, meta[:line]) do
+      true ->
+        {already_mutated_lines, ast}
+      _ ->
+        {mutated_lines, mutated_args} =
+        mutate_all(args, mutator, lines_to_mutate, already_mutated_lines)
+        {mutated_lines, {operator, meta, mutated_args}}
+    end
+  end
+
+  def mutate_all(
+    {operator, meta, args} = ast, mutator, lines_to_mutate, already_mutated_lines
   ) do
     case Enum.member?(lines_to_mutate, meta[:line]) do
       true ->

--- a/lib/foo_bar.ex
+++ b/lib/foo_bar.ex
@@ -1,3 +1,7 @@
 defmodule FooBar do
   def sub(a, b), do: a - b
+
+  def list_sum(list), do: Enum.reduce(list, 0, &add/2)
+
+  defp add(a, b), do: a + b
 end

--- a/test/foo_bar_test.exs
+++ b/test/foo_bar_test.exs
@@ -3,7 +3,11 @@ defmodule FooBarTest do
 
   @subject FooBar
 
-  test "when 0, 0" do
+  test "when 0, sub 0" do
     assert @subject.sub(0, 0) == 0
+  end
+
+  test "when [1, 2, 3], list_sum 6" do
+    assert @subject.list_sum([1, 2, 3]) == 6
   end
 end


### PR DESCRIPTION
Fixes [this](https://github.com/dnlserrano/exavier/issues/2) issue.
We now mutate `:/`operator in case when it's an arithmetic operator.